### PR TITLE
Adds MPL 2.0 license headers to source files

### DIFF
--- a/app/src/main/java/com/silentcid/homemind/repository/GroceryRepository.kt
+++ b/app/src/main/java/com/silentcid/homemind/repository/GroceryRepository.kt
@@ -1,6 +1,5 @@
 package com.silentcid.homemind.repository
 
-import com.silentcid.homemind.data.dao.GroceryDao
 import com.silentcid.homemind.data.models.GroceryItem
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject

--- a/app/src/main/java/com/silentcid/homemind/ui/components/ExpandableGroceryList.kt
+++ b/app/src/main/java/com/silentcid/homemind/ui/components/ExpandableGroceryList.kt
@@ -1,3 +1,10 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+
 package com.silentcid.homemind.ui.components
 
 import androidx.annotation.StringRes

--- a/app/src/main/java/com/silentcid/homemind/ui/components/GroceryItemEntryRow.kt
+++ b/app/src/main/java/com/silentcid/homemind/ui/components/GroceryItemEntryRow.kt
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 package com.silentcid.homemind.ui.components
 
 import com.silentcid.homemind.data.models.PendingGroceryEntry

--- a/app/src/main/java/com/silentcid/homemind/ui/components/ToolBar.kt
+++ b/app/src/main/java/com/silentcid/homemind/ui/components/ToolBar.kt
@@ -1,3 +1,10 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+
 package com.silentcid.homemind.ui.components
 
 import androidx.annotation.StringRes

--- a/app/src/main/java/com/silentcid/homemind/ui/components/WelcomeCarousel.kt
+++ b/app/src/main/java/com/silentcid/homemind/ui/components/WelcomeCarousel.kt
@@ -1,3 +1,10 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+
 package com.silentcid.homemind.ui.components
 
 import android.content.res.Configuration


### PR DESCRIPTION
Adds the Mozilla Public License 2.0 license headers to relevant source files.

This ensures compliance and proper attribution for the codebase.
